### PR TITLE
Remove depreciated defined(@array) usage.

### DIFF
--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -985,7 +985,7 @@ sub _unpack_value() {
 	
 	# we should have either had the validation class manually passed in or at least been able to get it directly from
 	# the cluster. if we failed at both of these we don't know how to unpack the given value so die()
-	if (!defined(@{$self->{$mode}{$columnfamily}})) {
+	if (!@{$self->{$mode}{$columnfamily}}) {
 		die('[ERROR] Was unable to retrieve the validation class for column family $columnfamily. Unable to unpack\n');
 	}
 


### PR DESCRIPTION
Remove depreciated defined(@array) usage.

Note: Usage of defined(@array) will cause a warning in perl 5.16.
http://perldoc.perl.org/perl5160delta.html#New-Diagnostics
http://perldoc.perl.org/perldiag.html#defined%28%40array%29-is-deprecated
