### PR TITLE
Fix hosts/seed_nodes/do_not_discover_peers checking

### DIFF
--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -194,11 +194,11 @@ sub new() {
 		die('you must provide at least one cassandra host');
 	}
 
-	if (defined($opt{hosts})) {
+	if (defined($opt{hosts}) && !defined($opt{do_not_discover_peers})) {
 		die('hosts has been depricated for seed_nodes. please create object with \'do_not_discover_peers\' if you want to still manually provide hosts');
 	}
 
-	if (!defined($opt{seed_nodes})) {
+	if (!defined($opt{hosts}) && !defined($opt{seed_nodes})) {
 		die('you must provide at least one seed_node or create the object with \'do_not_discover_peers\' and pass \'hosts\' in the object creation');
 	}
 

--- a/t/30CQL_create_keyspace.t
+++ b/t/30CQL_create_keyspace.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use Log::Any::Adapter qw{ScreenColoredLevel min_level trace};
 use Test::More;
 
 use Data::Dumper;
@@ -22,6 +23,7 @@ require_ok( 'perlcassa' );
 my $dbh;
 
 $dbh = new perlcassa(
+    'do_not_discover_peers' => 1,
     'hosts' => [$test_host],
     'keyspace' => 'system',
 );

--- a/t/31CQL_basic_queries.t
+++ b/t/31CQL_basic_queries.t
@@ -22,6 +22,7 @@ require_ok( 'perlcassa' );
 my $dbh;
 
 $dbh = new perlcassa(
+    'do_not_discover_peers' => 1,
     'hosts' => [$test_host],
     'keyspace' => $test_keyspace,
 );

--- a/t/33CQL_decode_types.t
+++ b/t/33CQL_decode_types.t
@@ -22,6 +22,7 @@ plan tests => 34;
 require_ok( 'perlcassa' );
 
 my $dbh = new perlcassa(
+    'do_not_discover_peers' => 1,
     'hosts' => [$test_host],
     'keyspace' => $test_keyspace,
 );

--- a/t/38CQL_drop_keyspace.t
+++ b/t/38CQL_drop_keyspace.t
@@ -22,6 +22,7 @@ require_ok( 'perlcassa' );
 my $dbh;
 
 $dbh = new perlcassa(
+    'do_not_discover_peers' => 1,
     'hosts' => [$test_host],
     'keyspace' => $test_keyspace,
 );


### PR DESCRIPTION
This logic was not operating as advertised---there was no possible way to use 'hosts', which meant the test suite was failing.
