### PR TITLE
Remove leftover reference to Log::Any::Adapter

### DIFF
--- a/t/30CQL_create_keyspace.t
+++ b/t/30CQL_create_keyspace.t
@@ -2,7 +2,6 @@
 
 use strict;
 use warnings;
-use Log::Any::Adapter qw{ScreenColoredLevel min_level trace};
 use Test::More;
 
 use Data::Dumper;


### PR DESCRIPTION
Sorry, missed taking this out before I committed & submitted.
