### PR TITLE
Fix proposal for UUID/TimeUUID unpack

### DIFF
--- a/lib/perlcassa/Decoder.pm
+++ b/lib/perlcassa/Decoder.pm
@@ -205,13 +205,13 @@ sub unpack_uuid {
     my $packed_value = shift;
     my $data_type = shift;
     my $len = length($packed_value);
-    my $ret;
+    my @values;
     if ($len ==16) {
-		$ret = unpack('H8', $packed_value).'-'.unpack('x4H4', $packed_value).'-'.unpack('x6H4', $packed_value).'-'.unpack('x8H4', $packed_value).'-'.unpack('x10H12', $packed_value);
-	} else {
+        @values = unpack("H8 H4 H4 H12", $packed_value);
+    } else {
         die("[ERROR] Invalid uuid type.");
     }
-    return $ret;
+    return join("-", @values);
 }
 
 # Unpack a collection type. List, Map, or Set

--- a/lib/perlcassa/Decoder.pm
+++ b/lib/perlcassa/Decoder.pm
@@ -26,7 +26,6 @@ our %simple_unpack = (
 	'Int32Type' 		=> 'l>',
 	'LongType' 		=> 'q>',
 	'UTF8Type' 		=> 'a*',
-	'UUIDType' 		=> 'S',
 	'CounterColumnType'	=> 'q>'
 );
 
@@ -34,6 +33,8 @@ our %complicated_unpack = (
 	'IntegerType'		=> \&unpack_IntegerType,
 	'DecimalType'		=> \&unpack_DecimalType,
 	'InetAddressType'	=> \&unpack_ipaddress,
+	'UUIDType'			=> \&unpack_uuid,
+	'TimeUUIDType'		=> \&unpack_uuid
 );
 
 sub new {
@@ -194,6 +195,21 @@ sub unpack_ipaddress {
         $ret = inet_ntop(Socket::AF_INET(), $packed_value);
     } else {
         die("[ERROR] Invalid inet type.");
+    }
+    return $ret;
+}
+
+# Unpack uuid/uuidtime type
+# Returns a string
+sub unpack_uuid {
+    my $packed_value = shift;
+    my $data_type = shift;
+    my $len = length($packed_value);
+    my $ret;
+    if ($len ==16) {
+		$ret = unpack('H8', $packed_value).'-'.unpack('x4H4', $packed_value).'-'.unpack('x6H4', $packed_value).'-'.unpack('x8H4', $packed_value).'-'.unpack('x10H12', $packed_value);
+	} else {
+        die("[ERROR] Invalid uuid type.");
     }
     return $ret;
 }


### PR DESCRIPTION
When doing a CQL SELECT on an UUIDType column, it returns a short int containing only the first 2 bytes of the UUID.

Below a solution proposal returning a formated UUID string.
Adding also the CQL3 TimeUUIDType by the way
