### PR TITLE
CQL exec call using prepared statement

### DIFF
--- a/Changes
+++ b/Changes
@@ -29,3 +29,10 @@ Change History
 0.050	January 30, 2013
 	- Incompatible changes made to CQL3 results. Removed ttl and timestamp columns. Result columns now point directly to the values.
     	- Makefile now does not do live tests by default, they must now be enabled manually.
+
+dev
+    - The CQL3 exec call has been changed to use a prepared query underneath.
+      This means each exec will connect to the cassandra server twice.
+        - This fixes the issue with CQL 3.0.2 where numeric types were not
+          being quoted correctly.
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ my %config = (
     clean       => { FILES => "Debian_CPANTS.txt Perlcassa-*.tar.gz" },
 );
 
-my @patterns = qw( t/*.t t/*/*.t );
+my @patterns = qw( t/*.t );
 $config{test} = { TESTS => join ' ', map { glob } @patterns };
 
 print "=  => To run full tests requires a running local cassandra server <=  =\n" unless $live_tests;
@@ -41,10 +41,12 @@ print "=  => To run full tests requires a running local cassandra server <=  =\n
 if ($live_tests) {
     # TODO Allow selection of keyspace
     # TODO Allow selection of test server?
+    # Adds the tests from the 99live* folders
+    my @livepatterns = qw( t/99live*/*.t );
+    my $testfiles = join ' ', map { glob } @livepatterns ;
+    $config{test}->{TESTS} .= " ".$testfiles;
 }
 else {
-    # Don't run the tests in the 99live_tests folder
-    $config{test}->{TESTS} =~ s| t\/99live_tests\/.*\.t||g;
     print "Setting to skip live tests.\n";
 }
 

--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -318,7 +318,22 @@ sub column_family() {
 	}
 }
 
-sub pexec() {
+##
+# the CQL3 exec call
+# 
+# $obj->exec("SELECT * FROM users WHERE state='UT' AND birth_year = 1970");
+#
+# $obj->exec("SELECT * FROM users WHERE state=:state AND birth_year = :by", {state => 'UT', by => 1970} );
+#
+# Arguments:
+#   query - a string specifying the query to be run
+#   params - a hash of parameters to be substituted into the query
+#   attr - a hash of attributes used to specify options. No options work currently
+#
+# Returns:
+#   a perlcassa:CQL3Result object
+##
+sub exec() {
 	my ($self, $query, $params) = @_;
     my $compression = Cassandra::Compression::NONE;
 
@@ -379,97 +394,6 @@ sub pexec() {
 	return $resp;
 }
 
-##
-# the CQL3 exec call
-# 
-# $obj->exec("SELECT * FROM users WHERE state='UT' AND birth_year = 1970");
-#
-# $obj->exec("SELECT * FROM users WHERE state=:state AND birth_year = :by", {state => 'UT', by => 1970} );
-#
-# Arguments:
-#   query - a string specifying the query to be run
-#   params - a hash of parameters to be substituted into the query
-#   attr - a hash of attributes used to specify options. No options work currently
-#
-# Returns:
-#   a perlcassa:CQL3Result object
-##
-sub exec() {
-	my ($self, $query, $params) = @_;
-
-	# Bind parameters
-	my $prepared_query = prepare_inline_cql3($query, $params);
-
-	my $keyspace = $self->{keyspace};
-	$self->client_setup('keyspace' => $keyspace);
-
-	my $client = $self->{client};
-
-    if ($self->{debug}) {
-        print STDERR ""
-                ."Query         : $query\n"
-                ."Prepared      : $prepared_query\n"
-                ;
-    }   
-
-	my $query_result;
-	if (defined($self->{timeout})) {
-		local $SIG{ALRM} = sub { die "CQL Query Timed Out"; };
-		my $alarm = alarm($self->{timeout});
-		$query_result = $client->execute_cql3_query(
-			$prepared_query,
-			Cassandra::Compression::NONE,
-			Cassandra::ConsistencyLevel::ONE
-		);
-		alarm($alarm);
-	} else {
-		$query_result = $client->execute_cql3_query(
-			$prepared_query,
-			Cassandra::Compression::NONE,
-			Cassandra::ConsistencyLevel::ONE
-		);
-	}
-
-	my $resp = perlcassa::CQL3Result->new();
-	$resp->process_cql3_results($query_result);
-
-	return $resp;
-}
-
-##
-# Replace each :param_name with the quoted value of $params{param_name}
-# Note comments do not work, but string literals should.
-##
-sub prepare_inline_cql3 {
-    my $query = shift;
-    my $params = shift || {};
-    my $attr = shift || {};
-    my %h_params = %$params;
-
-    # Split on string literals. No nesting
-    my @split_query = split(/('[^']*'|"[^"]*")/, " ".$query." ");
-
-    # TODO split on comments as well
-    my @prepared;
-    for my $part (@split_query) {
-        if (defined($part)) {
-            # Check if it is string literal
-            if ($part =~ /^('|")/) {
-                push(@prepared, $part);
-            } else {
-                # Replace each parameter with quoted and escaped version
-                # Note this could probably be made faster if needed
-                # maybe rewritten for readability too...
-                while ($part =~ s/(\W):(\w+)(?=\W)/$1."'"._escape_quotes($h_params{$2})."'"/e) {}
-                push(@prepared, $part);
-            }
-        }
-    }
-    my $pq = join('', @prepared);
-    $pq =~ s/^\ |\ $//g; # remove the whitespace added at beginning
-    return $pq;
-}
-
 sub prepare_prepared_cql3 {
     my $query = shift;
 
@@ -500,14 +424,6 @@ sub prepare_prepared_cql3 {
     $pq =~ s/^\ |\ $//g; # remove the whitespace added at beginning
     return ($pq, $position_map);
 }
-
-# CQL3 requires quotes to be escaped by doubling them.
-sub _escape_quotes() {
-    my $str = shift;
-    $str =~ s/'/''/g;
-    return $str;
-}
-
 
 #####################################################################################################
 # execute() allows you to run CQL queries against Apache Cassandra

--- a/lib/perlcassa/Client.pm
+++ b/lib/perlcassa/Client.pm
@@ -59,15 +59,11 @@ sub get_cassandra_nodes() {
 	}
 
 	# execute the CQL3 query to get all of the avaliable peers from the system table
-	my $query = "SELECT * FROM system.peers";
-	my $params = ();
-	my $prepared_query = perlcassa::prepare_inline_cql3($query, $params);
-
 	my $qres;
 	local $SIG{ALRM} = sub { die "Getting seed nodes timed out"; };
 	my $alarm = alarm(10);
 	$qres = $client->execute_cql3_query(
-		$prepared_query,
+		"SELECT * FROM system.peers",
 		Cassandra::Compression::NONE,
 		Cassandra::ConsistencyLevel::ONE
 	);

--- a/lib/perlcassa/Decoder.pm
+++ b/lib/perlcassa/Decoder.pm
@@ -30,17 +30,19 @@ our %simple_packs = (
 );
 
 our %complicated_unpack = (
-	'IntegerType'		=> \&unpack_IntegerType,
-	'DecimalType'		=> \&unpack_DecimalType,
-	'InetAddressType'	=> \&unpack_ipaddress,
-	'UUIDType'			=> \&unpack_uuid,
-	'TimeUUIDType'		=> \&unpack_uuid
+	'org.apache.cassandra.db.marshal.IntegerType'		=> \&unpack_IntegerType,
+	'org.apache.cassandra.db.marshal.DecimalType'		=> \&unpack_DecimalType,
+	'org.apache.cassandra.db.marshal.InetAddressType'	=> \&unpack_ipaddress,
+	'org.apache.cassandra.db.marshal.UUIDType'			=> \&unpack_uuid,
+	'org.apache.cassandra.db.marshal.TimeUUIDType'		=> \&unpack_uuid
 );
 
 our %complicated_pack = (
 	'org.apache.cassandra.db.marshal.IntegerType'		=> \&pack_IntegerType,
 	'org.apache.cassandra.db.marshal.DecimalType'		=> \&pack_DecimalType,
 	'org.apache.cassandra.db.marshal.InetAddressType'	=> \&pack_ipaddress,
+	'org.apache.cassandra.db.marshal.UUIDType'			=> \&pack_uuid,
+	'org.apache.cassandra.db.marshal.TimeUUIDType'		=> \&pack_uuid
 );
 
 sub new {
@@ -238,6 +240,14 @@ sub unpack_uuid {
         die("[ERROR] Invalid uuid type.");
     }
     return join("-", @values);
+}
+
+# Takes a string uuid and returns the packed version for CQL3
+sub pack_uuid {
+    my $value = shift;
+    my @values = split(/-/, $value);
+    my $encoded = pack("H8 H4 H4 H4 H12", @values);
+    return $encoded;
 }
 
 # Unpack a collection type. List, Map, or Set

--- a/lib/perlcassa/Decoder.pm
+++ b/lib/perlcassa/Decoder.pm
@@ -3,7 +3,7 @@ package perlcassa::Decoder;
 use strict;
 use warnings;
 use base 'Exporter';
-our @EXPORT = qw(make_cql3_decoder);
+our @EXPORT = qw(make_cql3_decoder pack_val);
 
 use Math::BigInt;
 use Math::BigFloat;
@@ -16,17 +16,17 @@ use Cassandra::Types;
 
 # XXX this is yanked from perlcassa.pm. it should only be in one place
 # hash that contains pack templates for ValidationTypes
-our %simple_unpack = (
-	'AsciiType' 		=> 'A*',
-	'BooleanType' 		=> 'C',
-	'BytesType' 		=> 'a*',
-	'DateType' 		=> 'q>',
-	'FloatType' 		=> 'f>',
-	'DoubleType' 		=> 'd>',
-	'Int32Type' 		=> 'l>',
-	'LongType' 		=> 'q>',
-	'UTF8Type' 		=> 'a*',
-	'CounterColumnType'	=> 'q>'
+our %simple_packs = (
+	'org.apache.cassandra.db.marshal.AsciiType' 		=> 'A*',
+	'org.apache.cassandra.db.marshal.BooleanType' 		=> 'C',
+	'org.apache.cassandra.db.marshal.BytesType' 		=> 'a*',
+	'org.apache.cassandra.db.marshal.DateType' 		=> 'q>',
+	'org.apache.cassandra.db.marshal.FloatType' 		=> 'f>',
+	'org.apache.cassandra.db.marshal.DoubleType' 		=> 'd>',
+	'org.apache.cassandra.db.marshal.Int32Type' 		=> 'l>',
+	'org.apache.cassandra.db.marshal.LongType' 		=> 'q>',
+	'org.apache.cassandra.db.marshal.UTF8Type' 		=> 'a*',
+	'org.apache.cassandra.db.marshal.CounterColumnType'	=> 'q>'
 );
 
 our %complicated_unpack = (
@@ -35,6 +35,12 @@ our %complicated_unpack = (
 	'InetAddressType'	=> \&unpack_ipaddress,
 	'UUIDType'			=> \&unpack_uuid,
 	'TimeUUIDType'		=> \&unpack_uuid
+);
+
+our %complicated_pack = (
+	'org.apache.cassandra.db.marshal.IntegerType'		=> \&pack_IntegerType,
+	'org.apache.cassandra.db.marshal.DecimalType'		=> \&pack_DecimalType,
+	'org.apache.cassandra.db.marshal.InetAddressType'	=> \&pack_ipaddress,
 );
 
 sub new {
@@ -98,7 +104,6 @@ sub decode_column {
     my $data_type = $self->{metadata}->{default_value_type};
     if (defined($column_name)) {
         $data_type = $self->{metadata}->{value_types}->{$column_name};
-        $data_type =~ s/org\.apache\.cassandra\.db\.marshal\.//g;
     }
     my $value = undef;
     if (defined($column->{value})) {
@@ -128,8 +133,8 @@ sub unpack_val {
     my $data_type = shift;
 
     my $unpacked;
-    if (defined($simple_unpack{$data_type})) {
-        $unpacked = unpack($simple_unpack{$data_type}, $packed_value);
+    if (defined($simple_packs{$data_type})) {
+        $unpacked = unpack($simple_packs{$data_type}, $packed_value);
     } elsif ($data_type =~ /^(List|Map|Set)Type/) {
         # Need to unpack a collection of values
         $unpacked = unpack_collection($packed_value, $data_type);
@@ -141,6 +146,27 @@ sub unpack_val {
             die("[ERROR] Attempted to unpack unimplemented data type. ($data_type)");
     }
     return $unpacked;
+}
+
+sub pack_val {
+    my $value = shift;
+    my $data_type = shift;
+
+    my $packed;
+    if (defined($simple_packs{$data_type})) {
+        $packed = pack($simple_packs{$data_type}, $value);
+    } elsif ($data_type =~ /(List|Map|Set)Type/) {
+        # Need to pack the collection
+        $packed = pack_collection($value, $data_type);
+    } elsif (defined($complicated_unpack{$data_type})) {
+        # It is a complicated type
+        my $pack_sub = $complicated_pack{$data_type};
+        $packed = $pack_sub->($value);
+    } else {
+        die("[ERROR] Attempted to pack an unknown data type. ($data_type)");
+    }
+
+    return $packed;
 }
 
 # Convert a hex string to a signed bigint
@@ -232,7 +258,7 @@ sub unpack_collection {
     # items/pairs in the collection. Then it goes backward 2 bytes (16 bits)
     # and grabs 16-bit value again, but uses it to know how many items/pairs
     # to decode
-    if ($base_type =~ /^(List|Set)Type/) {
+    if ($base_type =~ /org\.apache\.cassandra\.db\.marshal\.(List|Set)Type/) {
         # Handle the list and set. They are bascally the same
         # Each item is unpacked as raw bytes, then unpacked by our normal
         # routine
@@ -243,7 +269,7 @@ sub unpack_collection {
             push(@{$unpacked}, $v);
         }
 
-    } elsif ($base_type =~ /^MapType/) {
+    } elsif ($base_type eq "org.apache.cassandra.db.marshal.MapType") {
         # Handle the map types
         # Each pair is unpacked as two groups of raw bytes, then unpacked by
         # our normal routines
@@ -260,6 +286,52 @@ sub unpack_collection {
         die("[BUG] You broke it. File a bug... What is '$data_type'?");
     }
     return $unpacked;
+}
+
+
+# Pack a collection type. List, Map, or Set
+# Expectations...
+#   For List and Set types the first arugment is expected to be an array.
+#
+#   For Map types... ? not implemented XXX
+#
+# Returns the packed stuff #XXX better comment
+sub pack_collection {
+    my $values = shift;
+    my $data_type = shift;
+    my $packed;
+    my ($base_type, $inner_type) = ($data_type =~ /^([^)]*)\(([^)]*)\)/);
+
+    # "n/( ... )"
+    # Note: the preceeding is the basic template for collections.
+    # The template code puts a 16-bit unsigned value, which is the number of
+    # items/pairs in the collection.
+    if ($base_type =~ /org\.apache\.cassandra\.db\.marshal\.(List|Set)Type/) {
+        # Handle the list and set. They are bascally the same.
+        # Pack each value as inner type
+        my @packed_values = map { pack_val($_, $inner_type) } @$values;
+        # Pack them all together. First count of elements, then each element
+        # is preceded by its length in bytes
+        my $encoded = pack("n/(n/a)", @packed_values);
+        $packed = $encoded;
+    } elsif ($base_type eq "org.apache.cassandra.db.marshal.MapType") {
+        die("[BUG] XXX Unable to pack map types.\n");
+        ## Handle the map types
+        ## Each pair is unpacked as two groups of raw bytes, then unpacked by
+        ## our normal routines
+        #my ($count, @values) = unpack("nX2n/(n/a n/a)", $values);
+        #my @inner_types = split(",", $inner_type);
+        #$unpacked = {};
+        #for (my $i = 0; $i < $count; $i++) {
+        #    my $k = unpack_val($values[($i*2+0)], $inner_types[0]);
+        #    my $v = unpack_val($values[($i*2+1)], $inner_types[1]);
+        #    $unpacked->{$k} = $v;
+        #}
+
+    } else {
+        die("[BUG] You broke it. File a bug... What is '$data_type'?");
+    }
+    return $packed;
 }
 
 1;

--- a/lib/perlcassa/Decoder.pm
+++ b/lib/perlcassa/Decoder.pm
@@ -302,7 +302,7 @@ sub unpack_uuid {
     my $len = length($packed_value);
     my @values;
     if ($len ==16) {
-        @values = unpack("H8 H4 H4 H12", $packed_value);
+        @values = unpack("H8 H4 H4 H4 H12", $packed_value);
     } else {
         die("[ERROR] Invalid uuid type.");
     }

--- a/t/40CQL_internal.t
+++ b/t/40CQL_internal.t
@@ -10,25 +10,27 @@ $|++;
 
 plan tests => 13;
 
-use perlcassa;# qw{prepare_inline_cql3};
+use perlcassa;# qw{prepare_prepared_cql3};
 
-is(perlcassa::prepare_inline_cql3("SELECT 'n:hello' FROM 'a \" this place';"),
-    "SELECT 'n:hello' FROM 'a \" this place';",
+is_deeply([perlcassa::prepare_prepared_cql3("SELECT 'n:hello' FROM 'a \" this place';")],
+    ["SELECT 'n:hello' FROM 'a \" this place';", []],
     "String literals.");
 
 my $params_01 = {
     query => "stu'ff",
     kv => "Wear Clause",
 };
-is(perlcassa::prepare_inline_cql3("SELECT :query FROM ks.cf WHERE key = :kv;  ", $params_01),
-    "SELECT 'stu''ff' FROM ks.cf WHERE key = 'Wear Clause';  ",
+is_deeply([perlcassa::prepare_prepared_cql3("SELECT :query FROM ks.cf WHERE key = :kv;  ", $params_01)],
+    ["SELECT ? FROM ks.cf WHERE key = ?;  "
+        , ['query', 'kv']
+    ],
     "Parameter binding.");
 
 my $params_02 = {
     query => "yay",
 };
-is(perlcassa::prepare_inline_cql3("select \":query\" from key = :query", $params_02),
-    "select \":query\" from key = 'yay'",
+is_deeply([perlcassa::prepare_prepared_cql3("select \":query\" from key = :query", $params_02)],
+    ["select \":query\" from key = ?", ['query']],
     "Parameter binding and string quoting mixed.");
 
 TODO: {
@@ -41,8 +43,10 @@ my $param_int = {
     iv => 7,
     viv => $varint_v,
 };
-is(perlcassa::prepare_inline_cql3("INSERT INTO all_types (pk, t_bigint, t_int, t_varint) VALUES ('int_test', :biv, :iv, :viv)", $param_int),
-    "INSERT INTO all_types (pk, t_bigint, t_int, t_varint) VALUES ('int_test', '8589934592', '7', '1000000000000000000001')",
+is_deeply([perlcassa::prepare_prepared_cql3("INSERT INTO all_types (pk, t_bigint, t_int, t_varint) VALUES ('int_test', :biv, :iv, :viv)", $param_int)],
+    ["INSERT INTO all_types (pk, t_bigint, t_int, t_varint) VALUES ('int_test', ?, ?, ?)",
+        ['biv', 'iv', 'viv']
+    ],
     "Quoting integer types.");
 
 # Check hex to big int conversion
@@ -56,4 +60,76 @@ is(perlcassa::Decoder::hex_to_bigint(1, "80"), "-128");
 is(perlcassa::Decoder::hex_to_bigint(1, "c9ca36523a215fffff"), "-1000000000000000000001");
 is(perlcassa::Decoder::hex_to_bigint(1, "f607c81f"), "-167262177");
 
+my $hex01 = "0000002801ade9b959b7cd0009aeccd49a03bf46643c67c8edcd";
+my $dec01 = "62831853071.7958647692528676655900576839433879875021";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex01), "org.apache.cassandra.db.marshal.DecimalType"),
+    $dec01,
+    "Unpack Decimal Type ok, positive large magnitude"
+);
+my $packed01 = perlcassa::Decoder::pack_val( $dec01, "org.apache.cassandra.db.marshal.DecimalType");
+is(unpack("H*", $packed01), $hex01, "Pack Decimal Type ok, positive large magnitude");
+
+my $hex02 = "00000023f607c81f";
+my $dec02 = "-0.00000000000000000000000000167262177";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex02), "org.apache.cassandra.db.marshal.DecimalType"),
+    $dec02,
+    "Unpack Decimal Type ok, negative small magnitude"
+);
+my $packed02 = perlcassa::Decoder::pack_val( $dec02, "org.apache.cassandra.db.marshal.DecimalType");
+is(unpack("H*", $packed02), $hex02, "Pack Decimal Type ok, negative small magnitude");
+
+my $hex03 = "000000237607c81f";
+my $dec03 = "0.00000000000000000000000001980221471";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex03), "org.apache.cassandra.db.marshal.DecimalType"),
+    $dec03,
+    "Unpack Decimal Type ok, positive small magnitude"
+);
+my $packed03 = perlcassa::Decoder::pack_val( $dec03, "org.apache.cassandra.db.marshal.DecimalType");
+is(unpack("H*", $packed03), $hex03, "Pack Decimal Type ok, positive small magnitude");
+
+my $hex04 = "8936523a215fffff";
+my $int04 = "-8559563632149528577";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex04), "org.apache.cassandra.db.marshal.IntegerType"),
+    $int04,
+    "Unpack Integer type, negative even length hex"
+);
+my $packed04 = perlcassa::Decoder::pack_val( $int04, "org.apache.cassandra.db.marshal.IntegerType");
+is(unpack("H*", $packed04), $hex04, "Pack Decimal Type ok, negative even length hex");
+
+my $hex05 = "f8000000000000000000";
+my $int05 = "-37778931862957161709568";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex05), "org.apache.cassandra.db.marshal.IntegerType"),
+    $int05,
+    "Unpack Integer type, negative odd length hex"
+);
+my $packed05 = perlcassa::Decoder::pack_val( Math::BigInt->new($int05), "org.apache.cassandra.db.marshal.IntegerType");
+is(unpack("H*", $packed05), $hex05, "Pack Decimal Type ok, negative odd length hex");
+
+my $hex06 = "00800000000000000000";
+my $int06 = "2361183241434822606848";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex06), "org.apache.cassandra.db.marshal.IntegerType"),
+    $int06,
+    "Unpack Integer type, positive high bit set even length"
+);
+my $packed06 = perlcassa::Decoder::pack_val( Math::BigInt->new($int06), "org.apache.cassandra.db.marshal.IntegerType");
+is(unpack("H*", $packed06), $hex06, "Pack Decimal Type ok, positive high bit set even length");
+
+TODO: {
+    local $TODO = "Numbers with positive exponents do not get packed correctly.";
+    my $hex07 = "0000000010095dd9267e5007d565f1386b768370000000000000";
+    my $dec07 = "6000000000000000000000000000000000000000000000000000";
+    is(perlcassa::Decoder::unpack_val(
+            pack("H*", $hex07), "org.apache.cassandra.db.marshal.DecimalType"),
+        $dec07,
+        "Unpack Decimal Type ok, positive large magnitude"
+    );
+    my $packed07 = perlcassa::Decoder::pack_val( $dec07, "org.apache.cassandra.db.marshal.DecimalType");
+    is(unpack("H*", $packed07), $hex07, "Pack Decimal Type ok, positive large magnitude");
+}
 

--- a/t/40CQL_internal.t
+++ b/t/40CQL_internal.t
@@ -8,7 +8,7 @@ use Data::Dumper;
 
 $|++;
 
-plan tests => 13;
+plan tests => 27;
 
 use perlcassa;# qw{prepare_prepared_cql3};
 
@@ -120,15 +120,15 @@ is(perlcassa::Decoder::unpack_val(
 my $packed06 = perlcassa::Decoder::pack_val( Math::BigInt->new($int06), "org.apache.cassandra.db.marshal.IntegerType");
 is(unpack("H*", $packed06), $hex06, "Pack Decimal Type ok, positive high bit set even length");
 
+my $hex07 = "0000000010095dd9267e5007d565f1386b768370000000000000";
+my $dec07 = "6000000000000000000000000000000000000000000000000000";
+is(perlcassa::Decoder::unpack_val(
+        pack("H*", $hex07), "org.apache.cassandra.db.marshal.DecimalType"),
+    $dec07,
+    "Unpack Decimal Type ok, positive large magnitude"
+);
 TODO: {
     local $TODO = "Numbers with positive exponents do not get packed correctly.";
-    my $hex07 = "0000000010095dd9267e5007d565f1386b768370000000000000";
-    my $dec07 = "6000000000000000000000000000000000000000000000000000";
-    is(perlcassa::Decoder::unpack_val(
-            pack("H*", $hex07), "org.apache.cassandra.db.marshal.DecimalType"),
-        $dec07,
-        "Unpack Decimal Type ok, positive large magnitude"
-    );
     my $packed07 = perlcassa::Decoder::pack_val( $dec07, "org.apache.cassandra.db.marshal.DecimalType");
     is(unpack("H*", $packed07), $hex07, "Pack Decimal Type ok, positive large magnitude");
 }

--- a/t/99issue_tests/28CQL_integer_types.t
+++ b/t/99issue_tests/28CQL_integer_types.t
@@ -1,0 +1,91 @@
+#!/usr/bin/perl
+
+## 2013-03-21 Thu
+# This file relates to github issue #28.
+# https://github.com/mkjellman/perlcassa/issues/28
+#
+# CQL3 exec(): parameter hash doesn't work for int, uuid and timeuuid type columns
+#
+##
+
+
+use perlcassa;
+use UUID::Tiny;
+use Try::Tiny;
+
+use Data::Dumper;
+
+
+my $cassy = new perlcassa(
+    'keyspace' => "testspace",
+    'do_not_discover_peers' => 1,
+    'hosts' => ['localhost'],
+    'write_consistency_level' => Cassandra::ConsistencyLevel::QUORUM,
+    'read_consistency_level' => Cassandra::ConsistencyLevel::QUORUM,
+    'port' => '9160'
+);
+
+try {
+    $cassy->exec(
+        "CREATE TABLE testtable (key uuid," .
+        " ivalue int," .
+        " tvalue text," .
+        " PRIMARY KEY(key))"
+    );
+} catch {
+    print "Probably table existed before\n";
+};
+
+
+my $key = create_UUID_as_string();
+try {
+    $cassy->exec(
+        "INSERT INTO testtable (key, ivalue, tvalue)" .
+        " VALUES ($key, 123, 'teststring1')"
+    );
+    print "Test 1 succeeded\n";
+} catch {
+    print "Test 1 failed: ".Dumper(\$_)."\n";
+};
+
+$key = create_UUID_as_string();
+try {
+    $cassy->exec(
+        "INSERT INTO testtable (key, ivalue, tvalue)" .
+        " VALUES (:keyvalue, 234, 'teststring2')",
+        {
+            keyvalue => $key
+        }
+    );
+    print "Test 2 succeeded\n";
+} catch {
+    print "Test 2 failed: ".Dumper(\$_)."\n";
+};
+
+$key = create_UUID_as_string();
+try {
+    $cassy->exec(
+        "INSERT INTO testtable (key, ivalue, tvalue)" .
+        " VALUES ($key, :ivalue, 'teststring3')",
+        {
+            ivalue => 345,
+        }
+    );
+    print "Test 3 succeeded\n";
+} catch {
+    print "Test 3 failed: ".Dumper(\$_)."\n";
+};
+
+$key = create_UUID_as_string();
+try {
+    $cassy->exec(
+        "INSERT INTO testtable (key, ivalue, tvalue)" .
+        " VALUES ($key, 456, :tvalue)",
+        {
+            tvalue => 'teststring4'
+        }
+    );
+    print "Test 4 succeeded\n";
+} catch {
+    print "Test 4 failed: ".Dumper(\$_)."\n";
+};

--- a/t/99issue_tests/README
+++ b/t/99issue_tests/README
@@ -1,0 +1,3 @@
+
+These files are test cases related to issues raised on Github.
+

--- a/t/99live_tests/30CQL_create_keyspace.t
+++ b/t/99live_tests/30CQL_create_keyspace.t
@@ -37,7 +37,7 @@ TODO: {
     ok($res, "Drop testing keyspace ($test_keyspace).");
 }
 
-$res = $dbh->exec("CREATE KEYSPACE $test_keyspace WITH REPLICATION = {'CLASS' : 'SimpleStrategy', 'replication_factor': 1};");
+$res = $dbh->exec("CREATE KEYSPACE $test_keyspace WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1};");
 ok($res, "Create test keyspace ($test_keyspace).");
 
 $res = $dbh->exec(" CREATE TABLE $test_keyspace.user_profiles ( user_id text PRIMARY KEY, first_name text, last_name text, year_of_birth int) WITH COMPACT STORAGE");

--- a/t/99live_tests/33CQL_decode_types.t
+++ b/t/99live_tests/33CQL_decode_types.t
@@ -81,7 +81,7 @@ my $row_fp1 = $res->fetchone();
 is($row_fp1->{t_double}, 1234.5, "Check double value.");
 is($row_fp1->{t_float}, 9.875, "Check float value.");
 is($row_fp1->{t_decimal}, $float1_s,
-    "Check decimal (arbitrary precision float) value.");
+    "Check decimal large (arbitrary precision float) value.");
 
 # Check negative floating point types
 my $float2_s = '-0.00000000000000000000000000167262177';
@@ -93,8 +93,31 @@ my $row_fp2 = $res->fetchone();
 is($row_fp2->{t_double}, -0.000012345, "Check negative double value.");
 is($row_fp2->{t_float}, -0.5, "Check negative float value.");
 is($row_fp2->{t_decimal}, $float2_s,
-    "Check negative decimal (arbitrary precision float) value.");
+    "Check negative decimal small (arbitrary precision float) value.");
 
+# Check floating point types
+my $float3_s = '-62831853071.7958647692528676655900576839433879875021';
+my $float3 = Math::BigFloat->new($float3_s);
+my $param_fp3 = { dv => 1234.5, fv => 9.875, av => $float3, };
+$res = $dbh->exec("INSERT INTO all_types (pk, t_float, t_double, t_decimal) VALUES ('float_test3', :fv, :dv, :av)", $param_fp3);
+$res = $dbh->exec("SELECT pk, t_float, t_double, t_decimal FROM all_types WHERE pk = 'float_test3'");
+my $row_fp3 = $res->fetchone();
+is($row_fp3->{t_double}, 1234.5, "Check double value.");
+is($row_fp3->{t_float}, 9.875, "Check float value.");
+is($row_fp3->{t_decimal}, $float3_s,
+    "Check negative decimal large (arbitrary precision float) value.");
+
+# Check small floating point types
+my $float4_s = '0.00000000000000000000000001980221471';
+my $float4 = Math::BigFloat->new($float4_s);
+my $param_fp4 = { dv => -0.000012345, fv => -0.5, av => $float4 };
+$res = $dbh->exec("INSERT INTO all_types (pk, t_float, t_double, t_decimal) VALUES ('float_test4', :fv, :dv, :av)", $param_fp4);
+$res = $dbh->exec("SELECT pk, t_float, t_double, t_decimal FROM all_types WHERE pk = 'float_test4'");
+my $row_fp4 = $res->fetchone();
+is($row_fp4->{t_double}, -0.000012345, "Check negative double value.");
+is($row_fp4->{t_float}, -0.5, "Check negative float value.");
+is($row_fp4->{t_decimal}, $float4_s,
+    "Check decimal small (arbitrary precision float) value.");
 
 # Check integer types
 my $varint_v = Math::BigInt->new("1000000000000000000001");

--- a/t/99live_tests/33CQL_decode_types.t
+++ b/t/99live_tests/33CQL_decode_types.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More;
 use Math::BigInt;
 use Math::BigFloat;
+use UUID::Tiny;
 
 use Data::Dumper;
 
@@ -213,6 +214,15 @@ $res = $dbh->exec("SELECT pk, t_ascii, WRITETIME(t_ascii), TTL(t_ascii) FROM all
 $row_ttl = $res->fetchone();
 is($row_ttl, undef, "Check TTL expiration.");
 
+# Test UUID types
+my $uuid_params01 = { tuuid => create_UUID_as_string(UUID_V1), uuid => create_UUID_as_string(UUID_V4) };
+$res = $dbh->exec("INSERT INTO all_types (pk, t_timeuuid, t_uuid) VALUES ( 'uuid_test', :tuuid, :uuid)",
+    $uuid_params01
+);
+$res = $dbh->exec("SELECT pk, t_timeuuid, t_uuid FROM all_types WHERE pk = 'uuid_test'");
+my $row01_uuid01 = $res->fetchone();
+is($row01_uuid01->{t_timeuuid}, $uuid_params01->{tuuid}, "Check Time UUID insert and retrieval.");
+is($row01_uuid01->{t_uuid}, $uuid_params01->{uuid}, "Check UUID insert and retrieval.");
 
 
 # Clean up our tables
@@ -222,12 +232,12 @@ $res = $dbh->exec("DROP TABLE collection_types");
 ok($res, "Drop test table collection_types.");
 
 
+$dbh->finish();
+
 
 # Still need to implement/fix and test
 #  blob
 #  timestamp
-#  timeuuid
-#  uuid
 #  counters
 
 # Partial Support. UTF8 does not work correctly
@@ -247,6 +257,7 @@ ok($res, "Drop test table collection_types.");
 #  map
 #  set
 #  list
+#  timeuuid
+#  uuid
 
-$dbh->finish();    
 

--- a/t/99live_tests/33CQL_decode_types.t
+++ b/t/99live_tests/33CQL_decode_types.t
@@ -18,7 +18,7 @@ use vars qw($test_host $test_keyspace);
 $test_host = 'localhost';
 $test_keyspace = 'xx_testing_cql';
 
-plan tests => 34;
+plan tests => 42;
 
 require_ok( 'perlcassa' );
 


### PR DESCRIPTION
This should fix issue #28.

The exec call now uses prepared statements. This allows for proper support of numeric types. It is also the basis for future creation of a prepared statement call. 

What does not work:
- decimal types
- map types
- list/set types... might work, but untested.

@mkjellman could you do a basic once over of the code to make sure I didn't do anything crazy?
