### PR TITLE
Typo fixed in the exec function (%opts instead of $opts)

### DIFF
--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -334,7 +334,7 @@ sub column_family() {
 #   a perlcassa:CQL3Result object
 ##
 sub exec() {
-	my ($self, $query, $params, $opts) = @_;
+	my ($self, $query, $params, %opts) = @_;
     my $compression = Cassandra::Compression::NONE;
 	my $consistencylevel = $opts{consistency_level} || $self->{write_consistency_level};
 


### PR DESCRIPTION
Typo fixed in the exec function (%opts instead of $opts)
