### PR TITLE
   Column validation was not working for types other than INT.

### DIFF
--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -566,7 +566,7 @@ sub get_validators() {
 	$default_columnvalidation =~ s/org\.apache\.cassandra\.db\.marshal\.//g;
 
 	my @column_validators;
-	push (@column_validators, $key_validationclass);
+        push (@column_validators, $default_columnvalidation);
 
 	my %validators = (
 		'column'	=> \@column_validators,

--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -856,6 +856,7 @@ sub bulk_insert() {
 	} else {
 		$client->batch_mutate( { $key => { $columnfamily => \@mutations }}, $consistencylevel);
 	}
+        close_conn();
 }
 
 


### PR DESCRIPTION
   Found a bug in get_validators function. Changes made in the perlcassa.pm in function get_validators.
The validation does not work for column values because the key_validator is being columns_validators array. However the column validator needs to be pushed. 
