### PR TITLE
Added simple authentication support to perlcassa

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ perlcassa can be installed by doing the usual:
         'seed_nodes' => ['host1.cassandra.local',
                      'host2.cassandra.local',
                      'host3.cassandra.local'],
-        #optional
+        # optional
         'write_consistency_level' => Cassandra::ConsistencyLevel::QUORUM,
         'read_consistency_level' => Cassandra::ConsistencyLevel::QUORUM,
-        'port' => '9160'
+        'port' => '9160',
+        
+        # authentication
+        'credentials' => {
+           'username' => 'myusername',
+           'password' => 'mypassword'
+        },
     );
     
     my %composite = ('values' => ['name_pt1', 'name_pt2']);

--- a/lib/perlcassa.pm
+++ b/lib/perlcassa.pm
@@ -18,10 +18,16 @@ v0.060
         'seed_nodes' => ['host1.cassandra.local',
                      'host2.cassandra.local',
                      'host3.cassandra.local'],
-        #optional
+        # optional
         'write_consistency_level' => Cassandra::ConsistencyLevel::QUORUM,
         'read_consistency_level' => Cassandra::ConsistencyLevel::QUORUM,
-        'port' => '9160'
+        'port' => '9160',
+
+        # authentication
+        'credentials' => {
+           'username' => 'myusername',
+           'password' => 'mypassword'
+        },
     );
     
     my %composite = ('values' => ['name_pt1', 'name_pt2']);
@@ -224,7 +230,8 @@ sub new() {
 		failure_thread_running => 0,
 		max_retry => $opt{max_retry} || 2, # max number of times to try and connect for this request
 		donotpack => $opt{donotpack} || 0, #will insert with raw values and not autopack values
-		do_not_discover_peers => $opt{do_not_discover_peers} || undef
+		do_not_discover_peers => $opt{do_not_discover_peers} || undef,
+                credentials => $opt{credentials} || undef
 	}, $class;
 
 	# generate the inital randomized server list

--- a/lib/perlcassa/Client.pm
+++ b/lib/perlcassa/Client.pm
@@ -48,6 +48,9 @@ sub get_cassandra_nodes() {
 
 		eval {
 			$transport->open();
+
+ 			# Authenticate the client
+			authenticate($client, $self->{credentials}{username}, $self->{credentials}{password});
 		};
 
 		if ($@) {
@@ -88,6 +91,28 @@ sub get_cassandra_nodes() {
 	}
 
 	return %cass_hosts;
+}
+
+=item authenticate
+authenticate the client
+=cut
+sub authenticate {
+	my ($client, $username, $password) = @_;
+	if ($username and $password) {
+		eval {
+			my $auth = Cassandra::AuthenticationRequest->new( {
+				credentials =>
+				{
+					username => $username,
+					password => $password
+				}
+			} );
+			$client->login($auth);
+		};
+		if ($@) {
+			print STDERR "Failed to authenticate ";
+		}
+	};
 }
 
 =item generate_server_list
@@ -288,6 +313,9 @@ sub setup() {
 
 			eval {
 				$self->{transport}->open();
+
+				# Authenticate the client
+				authenticate( $self->{client}, $self->{credentials}{username}, $self->{credentials}{password} );
 			};
 
 			if ($@) {


### PR DESCRIPTION
Tried to add authentication support for perlcassa. Please feel free to re-factor. It works for me on a single-node Cassandra 2.1 cluster with PasswordAuthenticator.

```
 my $client = new perlcassa(
      keyspace => 'mykeyspace,
      hosts => ['localhost'],
      do_not_discover_peers => 1,
      'credentials' => { 'username' => 'cassandra', 'password' => 'cassandra' },
 );
 my $result = $client->exec("SELECT id from my_table limit 1");
```
